### PR TITLE
Fixed default 'callback_url' for websites using $f3->PORT

### DIFF
--- a/lib/opauth/OpauthBridge.php
+++ b/lib/opauth/OpauthBridge.php
@@ -27,7 +27,7 @@ class OpauthBridge extends \Prefab {
 		if (!isset($config['path']))
 			$config['path'] = $f3->BASE.'/'.$config['auth_route'].'/';
 		if (!isset($config['callback_url']))
-			$config['callback_url'] = $f3->SCHEME.'://'.$f3->HOST.$f3->BASE.'/'.
+			$config['callback_url'] = $f3->SCHEME.'://'.$f3->HOST.($f3->PORT?':'.$f3->PORT:'').$f3->BASE.'/'.
 				$config['callback_route'];
 		if (!isset($config['callback_transport']))
 			$config['callback_transport'] = 'post';


### PR DESCRIPTION
My server runs at at a specific port and the default way of creating `callback_url` in `OpauthBridge.php` didn't take `$f3->PORT` into consideration. This fixes it. 

Possible risk: this will append `:port` to production callback URLs. 

I know I can set `callback_url` in config, but the default settings didn't work for me and I spent way too much time debugging this. 

Your call to merge :) 