### PR TITLE
fix: github user endpoint require auth token via headers

### DIFF
--- a/lib/opauth/Strategy/Github/GithubStrategy.php
+++ b/lib/opauth/Strategy/Github/GithubStrategy.php
@@ -125,7 +125,8 @@ class GitHubStrategy extends OpauthStrategy {
 	 * @return array Parsed JSON results
 	 */
 	private function user($access_token) {
-		$user = $this->serverGet('https://api.github.com/user', array('access_token' => $access_token), null, $headers);
+		$options = array('http' => array('header' => "Authorization: token $access_token"));
+		$user = $this->serverGet('https://api.github.com/user', [], $options, $headers);
 
 		if (!empty($user)) {
 			return $this->recursiveGetObjectVars(json_decode($user));


### PR DESCRIPTION
Pass authentication token via headers, as the query method is now obsolete
see: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/